### PR TITLE
Converters input/output font size is not valid

### DIFF
--- a/src/Calculator.Shared/Views/UnitConverter.xaml
+++ b/src/Calculator.Shared/Views/UnitConverter.xaml
@@ -200,7 +200,7 @@
 		<Style x:Key="ValueMediumStyle"
                BasedOn="{StaticResource ValueBaseStyle}"
                TargetType="controls:CalculationResult">
-			<Setter Property="MaxFontSize" Value="34"/>
+			<Setter Property="MaxFontSize" Value="46"/>
 			<Setter Property="Margin" Value="0,0,0,0"/>
 			<Setter Property="DisplayMargin" Value="0,0,0,4"/>
 		</Style>
@@ -502,6 +502,7 @@
                                         DisplayValue="{x:Bind Model.Value1, Mode=OneWay}"
                                         ExpressionVisibility="Collapsed"
                                         FlowDirection="{x:Bind LayoutDirection}"
+										FontSize="{StaticResource CalcResultFontSizeM}"
                                         IsActive="{Binding Value1Active, Mode=TwoWay}"
                                         KeyDown="OnValueKeyDown"
                                         ValueSelected="OnValueSelected"
@@ -558,6 +559,7 @@
                                         DisplayValue="{x:Bind Model.Value2, Mode=OneWay}"
                                         ExpressionVisibility="Collapsed"
                                         FlowDirection="{x:Bind LayoutDirection}"
+										FontSize="{StaticResource CalcResultFontSizeM}"
                                         IsActive="{Binding Value2Active, Mode=TwoWay}"
                                         KeyDown="OnValueKeyDown"
                                         ValueSelected="OnValueSelected"


### PR DESCRIPTION
* Fixed the converter fonts by setting a font size value on the Calculation result controls

## Fixes #.


### Description of the changes:
- Fixed the converter fonts by setting a font size value on the Calculation result controls
-
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested on all 4 platforms (UWP, Android, iOS, WASM)
-
-

