### PR TITLE
[Perf] Set x:Load=false for StandardOperators

### DIFF
--- a/src/Calculator.Shared/Views/Calculator.xaml.cs
+++ b/src/Calculator.Shared/Views/Calculator.xaml.cs
@@ -301,6 +301,11 @@ namespace CalculatorApp
 
         void OnIsStandardPropertyChanged(bool oldValue, bool newValue)
         {
+			if (newValue)
+			{
+				EnsureStandard();
+			}
+
             UpdateViewState();
             UpdatePanelViewState();
         }
@@ -429,6 +434,11 @@ namespace CalculatorApp
                 }
             }
         }
+
+		void EnsureStandard()
+		{
+			OpsPanel.EnsureStandardOps();
+		}
 
         void EnsureScientific()
         {

--- a/src/Calculator.Shared/Views/OperatorsPanel.xaml
+++ b/src/Calculator.Shared/Views/OperatorsPanel.xaml
@@ -11,7 +11,7 @@
 	<Grid>
 		<!--Bind visibility as a workaround for nventive/Uno#925-->
 		<local:CalculatorStandardOperators x:Name="StandardOperators"
-																			 x:Load="{x:Bind Model.IsStandard, Mode=OneWay}"
+																			 x:Load="False"
 																			 IsEnabled="{x:Bind Model.IsStandard, Mode=OneWay}"
 																			 Visibility="{x:Bind Model.IsStandard, Mode=OneWay}"
 																			 TabIndex="17" />

--- a/src/Calculator.Shared/Views/OperatorsPanel.xaml.cs
+++ b/src/Calculator.Shared/Views/OperatorsPanel.xaml.cs
@@ -88,6 +88,14 @@ namespace CalculatorApp
 			}
 		}
 
+		internal void EnsureStandardOps()
+		{
+			if (StandardOperators == null)
+			{
+				this.FindName("StandardOperators");
+			}
+		}
+
 		internal void EnsureScientificOps()
 		{
 			if (ScientificOperators == null)


### PR DESCRIPTION
As a workaround for nventive/Uno#925 (binding to x:Load doesn't work), this improves start-up time when going directly to calculators other than Standard.

## Fixes #.


### Description of the changes:
-
-
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-
-
-

