### PR TITLE
Remove temporary fix that was causing glitches

### DIFF
--- a/src/Calculator.Shared/Views/CalculatorScientificOperators.xaml
+++ b/src/Calculator.Shared/Views/CalculatorScientificOperators.xaml
@@ -262,18 +262,6 @@
 					<Storyboard Completed="WideLayout_Completed" />
 				</VisualState>
 
-				<!-- UNO TODO Temp fix for iphoneX-->
-				<VisualState x:Name="Landscape">
-					<VisualState.StateTriggers>
-						<AdaptiveTrigger MinWindowHeight="768"
-										 MinWindowWidth="1366" />
-					</VisualState.StateTriggers>
-					<VisualState.Setters>
-						<Setter Target="NumberPad.ButtonStyle"
-								Value="{ThemeResource NumericButtonStyle12}" />
-					</VisualState.Setters>
-				</VisualState>
-				
 				<VisualState x:Name="WideL">
 					<VisualState.StateTriggers>
 						<AdaptiveTrigger MinWindowHeight="768"


### PR DESCRIPTION
Remove extra VisualState that was added to fix text cut off on iPhone X landscape. This was misapplying on desktop/WASM at large widths and causing buttons to be overlaid.

Tested on iPhone X and iPhone 7 and confirmed that this is no longer necessary.

# Internal issues:
https://nventive.visualstudio.com/Umbrella/_workitems/edit/155171
https://nventive.visualstudio.com/Umbrella/_workitems/edit/155176

## Fixes #.


### Description of the changes:
-
-
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-
-
-

