### PR TITLE
Updated Git Clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Prerequisites:
 
 - Get the code:
     ```
-    git clone https://github.com/nventive/calculator
+    git clone https://github.com/unoplatform/calculator
     ```
 
 - Open [src\Calculator.sln](/src/Calculator.sln) in Visual Studio to build and run the Calculator app.


### PR DESCRIPTION
## Fixes #. Updated Git Clone URL to https://github.com/unoplatform/calculator
