### PR TITLE
Enable number pad pointer over states

### DIFF
--- a/src/Calculator.Shared/Styles.xaml
+++ b/src/Calculator.Shared/Styles.xaml
@@ -167,7 +167,7 @@
 									   Color="#17000000" />
 
 			<xamarin:SolidColorBrush x:Key="AppControlHoverButtonFaceBrush"
-									 Color="{ThemeResource SystemColorHighlightColor}" />
+									 Color="#17000000" />
 
 			<win:RevealBackgroundBrush x:Key="AppControlPressedButtonFaceBrush"
 									   Color="#30000000" />

--- a/src/Calculator.Shared/Styles.xaml
+++ b/src/Calculator.Shared/Styles.xaml
@@ -329,7 +329,7 @@
 													  To="KeyBoardEntry" />
 								</VisualStateGroup.Transitions>
 								<VisualState x:Name="Normal" />
-								<win:VisualState x:Name="PointerOver">
+								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
 										<Setter Target="RootGrid.(RevealBrush.State)"
 												Value="PointerOver" />
@@ -338,7 +338,7 @@
 										<Setter Target="ContentPresenter.(ContentPresenter.Foreground)"
 												Value="{Binding HoverForeground, RelativeSource={RelativeSource TemplatedParent}}" />
 									</VisualState.Setters>
-								</win:VisualState>
+								</VisualState>
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
 										<Setter Target="RootGrid.(RevealBrush.State)"
@@ -476,7 +476,7 @@
 													  To="KeyBoardEntry" />
 								</VisualStateGroup.Transitions>
 								<VisualState x:Name="Normal" />
-								<win:VisualState x:Name="PointerOver">
+								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
 										<Setter Target="RootGrid.(RevealBrush.State)"
 												Value="PointerOver" />
@@ -487,7 +487,7 @@
 										<Setter Target="ParenthesisCount.Foreground"
 												Value="{Binding HoverForeground, RelativeSource={RelativeSource TemplatedParent}}" />
 									</VisualState.Setters>
-								</win:VisualState>
+								</VisualState>
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
 										<Setter Target="RootGrid.(RevealBrush.State)"
@@ -565,7 +565,7 @@
 													  To="KeyBoardEntry" />
 								</VisualStateGroup.Transitions>
 								<VisualState x:Name="Normal" />
-								<win:VisualState x:Name="PointerOver">
+								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
 										<Setter Target="RootGrid.(RevealBrush.State)"
 												Value="PointerOver" />
@@ -574,7 +574,7 @@
 										<Setter Target="ContentPresenter.(ContentPresenter.Foreground)"
 												Value="{ThemeResource AccentHoverForegroundColorBrush}" />
 									</VisualState.Setters>
-								</win:VisualState>
+								</VisualState>
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
 										<Setter Target="RootGrid.(RevealBrush.State)"

--- a/src/Calculator.Shared/Styles.xaml
+++ b/src/Calculator.Shared/Styles.xaml
@@ -98,7 +98,7 @@
 									   Color="#18FFFFFF" />
 
 			<xamarin:SolidColorBrush x:Key="AppControlHoverButtonFaceBrush"
-									 Color="{ThemeResource SystemColorHighlightColor}" />
+									 Color="#18FFFFFF" />
 
 			<win:RevealBackgroundBrush x:Key="AppControlPressedButtonFaceBrush"
 									   Color="#30FFFFFF" />


### PR DESCRIPTION
Related issue: Fixes https://github.com/unoplatform/private/issues/103


### Description of the changes:
Enables pointer-over states in the number pads on WASM, fixes colour for `M+`/etc buttons. 

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-
-
-

